### PR TITLE
added GTA: Sindacco Chronicles support

### DIFF
--- a/plugin.ini
+++ b/plugin.ini
@@ -10,3 +10,4 @@ ULES00151 = true
 ULUS10160 = true
 ULES00502 = true
 ULES00503 = true
+ULUS01826 = true


### PR DESCRIPTION
added support for GTA LCS mod, GTA: Sindacco Chronicles, available here: https://barcode-studia.ru/mods/sindacco-chronicles/

Cheat Device and trophies with the same changes in plugin.ini files also works with this GTA LCS mod on PPSSPP